### PR TITLE
Fix ESLint link

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ In Java 8, javac will feature an `-Xdoclint` option to identify undocumented cod
 
 ## JavaScript / Node.js
 
-[ESLint](eslint.org) is a pluggable and configurable javascript linter that aims to fix the non-extensibility issues of JSHint and JSLint.
+[ESLint](http://eslint.org) is a pluggable and configurable javascript linter that aims to fix the non-extensibility issues of JSHint and JSLint.
 
 [JSHint](http://jshint.com/) is far and away the best modern linter available. It's simultaneously easy to use, and highly customizable; offering global and directory specific `.jshintrc` files for rule configuration; and global and directory specific `.jshintignore` files for ignoring certain files and directories, trimming down `jshint`'s output to exactly what you want to see.
 


### PR DESCRIPTION
The current ESLint link points to https://github.com/mcandre/linters/blob/master/eslint.org because the markdown link has no protocol. I just added `http://` in front of `eslint.org`.