### PR TITLE
update dead link for splint linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Many compilers include an option like `-Wall` to turn on warnings, `-Wextra` for
 
 ## C
 
-[splint](http://splint.org/) has largely replaced the old `lint` tool, offering the same old checks, as well as additional security checks.
+[splint](http://lclint.cs.virginia.edu/) has largely replaced the old `lint` tool, offering the same old checks, as well as additional security checks.
 
 [lint](http://www.unix.com/man-page/FreeBSD/1/lint) the original.
 


### PR DESCRIPTION
The previous link is unavailable